### PR TITLE
add --ca-cert option to allow specifying ca certificates for proper ssl validation

### DIFF
--- a/lib/cli/runner.rb
+++ b/lib/cli/runner.rb
@@ -50,9 +50,12 @@ class Cli < BaseCli
     @uaa_logger = Util.default_logger(opts[:trace]? :trace: opts[:debug]? :debug: :warn, @output)
   end
 
-  def self.uaa_info_client(url = Config.target, skip_ssl_validation = false)
-    skip_ssl_validation = Config.config[url][:skip_ssl_validation] if Config.config[url]
-    client = Info.new(url, { skip_ssl_validation: skip_ssl_validation })
+  def self.uaa_info_client(url = Config.target, skip_ssl_validation = false, ca_cert = nil)
+    if Config.config[url]
+      skip_ssl_validation = Config.config[url][:skip_ssl_validation]
+      ca_cert = Config.config[url][:ca_cert]
+    end
+    client = Info.new(url, { skip_ssl_validation: skip_ssl_validation, ssl_ca_file: ca_cert })
     client.logger = @uaa_logger
     client
   end

--- a/lib/cli/token.rb
+++ b/lib/cli/token.rb
@@ -25,7 +25,7 @@ class TokenCatcher < Stub::Base
     secret = server.info.delete(:client_secret)
     ti = TokenIssuer.new(Config.target, server.info.delete(:client_id), secret,
         { token_target: Config.target_value(:token_target),
-          skip_ssl_validation: Config.target_value(:skip_ssl_validation) })
+          skip_ssl_validation: Config.target_value(:skip_ssl_validation)})
     tkn = secret ? ti.authcode_grant(server.info.delete(:uri), data) :
         ti.implicit_grant(server.info.delete(:uri), data)
     server.info.update(token_info: tkn.info)
@@ -88,7 +88,8 @@ class TokenCli < CommonCli
     update_target_info
     yield TokenIssuer.new(Config.target.to_s, client_id, secret,
         { token_target: Config.target_value(:token_endpoint),
-          skip_ssl_validation: Config.target_value(:skip_ssl_validation) })
+          skip_ssl_validation: Config.target_value(:skip_ssl_validation),
+          ssl_ca_file: Config.target_value(:ca_cert) })
   rescue Exception => e
     complain e
   end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -89,6 +89,12 @@ describe CommonCli do
     Config.yaml.should include "skip_ssl_validation: true"
   end
 
+  it "accepts a root CA as a commandline parameter" do
+    Cli.run("target --force --ca-cert dir/rootCA.pem https://example.com")
+    Cli.output.string.should include "https://example.com"
+    Config.yaml.should include "ca_cert: dir/rootCA.pem"
+  end
+
   it "only attempts http if scheme is http" do
     Cli.run("target http://example.com")
     puts Cli.output.string


### PR DESCRIPTION
Signed-off-by: dmitriy kalinin <dkalinin@pivotal.io>