### PR TITLE
Allow user to set the home dir uaac uses with UAAC_HOME

### DIFF
--- a/bin/uaac
+++ b/bin/uaac
@@ -15,4 +15,6 @@
 
 $:.unshift File.expand_path File.join __FILE__, '..', '..', 'lib'
 require 'uaac_cli'
-exit CF::UAA::Cli.configure("#{ENV['HOME']}/.uaac.yml").run ? 0 : 1
+home = ENV['UAAC_HOME']
+home = ENV['HOME'] if home.nil? || home.empty?
+exit CF::UAA::Cli.configure("#{home}/.uaac.yml").run ? 0 : 1


### PR DESCRIPTION
This is analogous to the behavior of the cf cli, which has a CF_HOME environment variable. It's useful when you want to isolate your uaac session or easily switch between multiple contexts. In my team's case, we use an .envrc file to automatically change the CF_HOME (and now the UAAC_HOME) when you switch into the "env/prod" or "env/acceptance" directories, so you're automatically logged in, targeted, etc.