### PR TITLE
Remove bundler dep from gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.1

--- a/cf-uaac.gemspec
+++ b/cf-uaac.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
 
   # dependencies
   s.add_runtime_dependency 'cf-uaa-lib', '~> 3.11'
-  s.add_development_dependency 'bundler', '~> 1.14'
   s.add_development_dependency 'rake', '~> 10.3', '>= 10.3.1'
   s.add_development_dependency 'rspec', '~> 2.14', '>= 2.14.1'
   s.add_development_dependency 'simplecov', '~> 0.8.2'


### PR DESCRIPTION
We were requiring an older version of bundler, which won't work when folks use bundler2. I ran the specs and everything is find without explicit lockdown of bundler version to a 1.x line.