### PR TITLE
feature: enforce ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 [![Build Status](https://travis-ci.org/cloudfoundry/cf-uaac.svg?branch=master)](https://travis-ci.org/cloudfoundry/cf-uaac)
 [![Gem Version](https://badge.fury.io/rb/cf-uaac.png)](https://rubygems.org/gems/cf-uaac)
 
+## Dependencies
+
+### Ruby
+
+In order to run the `uaac` you need to have Ruby 2.3.1 or later, while
+not being Ruby 3.0.0 or later.
+
 ## Installation
 
 From Rubygems:

--- a/lib/uaa/cli/base.rb
+++ b/lib/uaa/cli/base.rb
@@ -22,6 +22,11 @@ module CF::UAA
 class Topic
 
   class << self; attr_reader :synonyms end
+  system_ruby_version = Gem::Version.new(RUBY_VERSION)
+  if system_ruby_version < Gem::Version.new('2.3.1') || system_ruby_version >= Gem::Version.new('3.0.0')
+    puts 'Your ruby version must be more recent than 2.3.1 while being 2.x, please update your ruby version'
+    exit 1
+  end
 
   def self.option_defs ; @option_defs || {} end
   def self.commands; @commands || {} end


### PR DESCRIPTION
The CLI is only supported with ruby versions from 2.3.1 included to
3.0.0 excluded.
