### PR TITLE
Ruby 3 support

### DIFF
--- a/cf-uaac.gemspec
+++ b/cf-uaac.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
   s.add_development_dependency 'ci_reporter', '>= 1.9.2', '~> 2.0'
   s.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
-  s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.21'
+  s.add_runtime_dependency 'highline', '~> 2.0'
   s.add_runtime_dependency 'eventmachine', '~> 1.0', '>= 1.0.3'
   s.add_runtime_dependency 'launchy', '~> 2.4', '>= 2.4.2'
   s.add_runtime_dependency 'em-http-request', '~> 1.1', '>= 1.1.2'

--- a/cf-uaac.gemspec
+++ b/cf-uaac.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # dependencies
-  s.add_runtime_dependency 'cf-uaa-lib', '>= 3.14.4'
+  s.add_runtime_dependency 'cf-uaa-lib', '~> 3.14', '> 3.14.3'
   s.add_development_dependency 'rake', '>= 10.3.1', '~> 13.0'
   s.add_development_dependency 'rspec', '>= 2.14.1', '~> 3.9'
   s.add_development_dependency 'simplecov', '~> 0.21.2'

--- a/cf-uaac.gemspec
+++ b/cf-uaac.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Command line interface for CloudFoundry UAA}
   s.description = %q{Client command line tools for interacting with the CloudFoundry User Account and Authorization (UAA) server.  The UAA is an OAuth2 Authorization Server so it can be used by webapps and command line apps to obtain access tokens to act on behalf of users.  The tokens can then be used to access protected resources in a Resource Server.  This library can be used by clients (as a convenient wrapper for mainstream oauth gems) or by resource servers.}
 
-  s.rubyforge_project = 'cf-uaac'
-
   s.license       = 'Apache-2.0'
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/client_reg_spec.rb
+++ b/spec/client_reg_spec.rb
@@ -58,8 +58,8 @@ describe ClientCli do
     end
 
     it 'does not wrap the output of the access token in the terminal' do
-      @output.stub(:tty?) { true }
-      HighLine::SystemExtensions.stub(:terminal_size) { [80] }
+      allow(@output).to receive(:tty?).and_return(true)
+      allow(HighLine::SystemExtensions).to receive(:terminal_size).and_return([80])
       Cli.run('context').should be
       Cli.output.string.should match /access_token: \S+?\s+token_type/m
     end

--- a/spec/client_reg_spec.rb
+++ b/spec/client_reg_spec.rb
@@ -59,7 +59,7 @@ describe ClientCli do
 
     it 'does not wrap the output of the access token in the terminal' do
       allow(@output).to receive(:tty?).and_return(true)
-      allow(HighLine::SystemExtensions).to receive(:terminal_size).and_return([80])
+      allow(HighLine::Terminal).to receive(:terminal_size).and_return([80, 40])
       Cli.run('context').should be
       Cli.output.string.should match /access_token: \S+?\s+token_type/m
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,12 @@ require 'rspec'
 require 'eventmachine'
 require 'uaa/stub/uaa'
 
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = [:expect, :should]
+  end
+end
+
 module CF::UAA
 
 module SpecHelper

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -69,7 +69,7 @@ describe UserCli do
     Cli.input = StringIO.new("password") # selecting first origin through stdin
     Cli.run("user add #{user_with_origin} " +
                 '--emails sam@example.com --given_name SamueL ' +
-                "--phones 801-555-1212 --family_name jonES --origin uaa").should be
+                "--phones 801-555-1212 --family_name jonES --origin uaa")
 
     expect(Cli.output.string).to match 'Password:'
     Cli.run("user delete #{user_with_origin}")
@@ -80,7 +80,7 @@ describe UserCli do
     Cli.input = StringIO.new("password") # selecting first origin through stdin
     Cli.run("user add #{user_with_origin} " +
                 '--emails sam@example.com --given_name SamueL ' +
-                "--phones 801-555-1212 --family_name jonES").should be
+                "--phones 801-555-1212 --family_name jonES")
 
     expect(Cli.output.string).to match 'Password:'
     Cli.run("user delete #{user_with_origin}")


### PR DESCRIPTION
Along with cloudfoundry/cf-uaa-lib#73, this PR brings Ruby 3 support in `cf-uaac`.

Unit tests have successfully run on my laptop with Ruby 2.7.2, 3.0.2, and 3.1.0.

I haven't run them in a CI pipeline with fresh set of gem dependencies, and I haven't run the integration tests yet. I'll update the status once this is done.