### PR TITLE
support client update attribute allowedproviders

### DIFF
--- a/lib/uaa/cli/client_reg.rb
+++ b/lib/uaa/cli/client_reg.rb
@@ -52,7 +52,7 @@ class ClientCli < CommonCli
         info[k] = Util.arglist(info[k]) if p == 'list'
         info.delete(k) unless info[k]
       end
-      if k == :allowedproviders && (info[k].join('') == 'all' || info[k].join('') == 'null' || info[k].join('') == 'nil')
+      if opts.key?(k) && k == :allowedproviders && (info[k].join('') == 'all' || info[k].join('') == 'null' || info[k].join('') == 'nil')
         info[:allowedproviders] = nil
       end
     end

--- a/lib/uaa/cli/client_reg.rb
+++ b/lib/uaa/cli/client_reg.rb
@@ -28,6 +28,7 @@ class ClientCli < CommonCli
       :refresh_token_validity => 'seconds',
       :redirect_uri => 'list',
       :autoapprove => 'list',
+      :allowedproviders => 'list',
       :'signup_redirect_url' => 'url'
   }
   CLIENT_SCHEMA.each { |k, v| define_option(k, "--#{k} <#{v}>") }
@@ -50,6 +51,9 @@ class ClientCli < CommonCli
       else
         info[k] = Util.arglist(info[k]) if p == 'list'
         info.delete(k) unless info[k]
+      end
+      if k == :allowedproviders && (info[k].join('') == 'all' || info[k].join('') == 'null' || info[k].join('') == 'nil')
+        info[:allowedproviders] = nil
       end
     end
   end

--- a/lib/uaa/stub/scim.rb
+++ b/lib/uaa/stub/scim.rb
@@ -65,7 +65,7 @@ class StubScim
         :authorizations, :groups].to_set,
       client: [*COMMON_ATTRS, :client_id, :name, :client_secret, :authorities,
         :authorized_grant_types, :scope, :autoapprove,
-        :access_token_validity, :refresh_token_validity, :redirect_uri,
+        :access_token_validity, :refresh_token_validity, :redirect_uri, :allowedproviders,
         :'signup_redirect_url'].to_set,
       group: [*COMMON_ATTRS, :displayname, :members, :writers, :readers, :external_groups].to_set }
   VISIBLE_ATTRS = {user: Set.new(LEGAL_ATTRS[:user] - HIDDEN_ATTRS),


### PR DESCRIPTION
Why: needed if uaa is connected to external IDPs

How:
a) uaac client update uaaclient --allowedproviders uaa,extOrigin,origin2
-> add list of allowed origins
b) uaac client update uaaclient --allowedproviders null
-> PUT null value and with that delete the setting and allow all