### PR TITLE
add basic_auth option and pass to cf-uaa-lib

### DIFF
--- a/cf-uaac.gemspec
+++ b/cf-uaac.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # dependencies
-  s.add_runtime_dependency 'cf-uaa-lib', '~> 3.14', '> 3.14.3'
+  s.add_runtime_dependency 'cf-uaa-lib', '~> 4.0'
   s.add_development_dependency 'rake', '>= 10.3.1', '~> 13.0'
   s.add_development_dependency 'rspec', '>= 2.14.1', '~> 3.9'
   s.add_development_dependency 'simplecov', '~> 0.21.2'

--- a/lib/uaa/cli/common.rb
+++ b/lib/uaa/cli/common.rb
@@ -186,7 +186,8 @@ class MiscCli < CommonCli
   define_option :ca_cert, "--ca-cert [file]", "use the given CA certificate to validate the target's SSL certificate"
   define_option :skip_ssl_validation, "--skip-ssl-validation", "do not attempt to validate ssl certificate"
   define_option :force, "--[no-]force", "-f", "set even if target does not respond"
-  desc "target [uaa_url]", "Display current or set new target", :force, :ca_cert, :skip_ssl_validation do |uaa_url|
+  define_option :basic_auth, "--[no-]basic_auth", "set if you need basic or oauth2 (url encoded) client authentication"
+  desc "target [uaa_url]", "Display current or set new target", :force, :ca_cert, :skip_ssl_validation, :basic_auth do |uaa_url|
     msg, info = nil, {}
     if uaa_url
       if uaa_url.to_i.to_s == uaa_url
@@ -204,6 +205,8 @@ class MiscCli < CommonCli
       Config.target = url # we now have a canonical url set to https if possible
       Config.target_opts(skip_ssl_validation: true) if opts[:skip_ssl_validation]
       Config.target_opts(ca_cert: opts[:ca_cert])
+      Config.target_opts(basic_auth: true) if opts[:basic_auth] == true
+      Config.target_opts(basic_auth: false) if opts[:basic_auth] == false
       update_target_info(info) if info[:prompts]
     end
     return say "no target set" unless Config.target

--- a/lib/uaa/cli/token.rb
+++ b/lib/uaa/cli/token.rb
@@ -88,7 +88,7 @@ class TokenCli < CommonCli
 
   def issuer_request(client_id, secret = nil)
     update_target_info
-    yield TokenIssuer.new(Config.target.to_s, CGI.escape(client_id), CGI.escape(secret),
+    yield TokenIssuer.new(Config.target.to_s, client_id, secret,
         { token_target: Config.target_value(:token_endpoint),
           skip_ssl_validation: Config.target_value(:skip_ssl_validation),
           ssl_ca_file: Config.target_value(:ca_cert) })

--- a/lib/uaa/cli/token.rb
+++ b/lib/uaa/cli/token.rb
@@ -25,6 +25,7 @@ class TokenCatcher < Stub::Base
     secret = server.info.delete(:client_secret)
     ti = TokenIssuer.new(Config.target, server.info.delete(:client_id), secret,
         { token_target: Config.target_value(:token_target),
+          basic_auth: Config.target_value(:basic_auth),
           skip_ssl_validation: Config.target_value(:skip_ssl_validation)})
     tkn = secret ? ti.authcode_grant(server.info.delete(:uri), data) :
         ti.implicit_grant(server.info.delete(:uri), data)
@@ -90,6 +91,7 @@ class TokenCli < CommonCli
     update_target_info
     yield TokenIssuer.new(Config.target.to_s, client_id, secret,
         { token_target: Config.target_value(:token_endpoint),
+          basic_auth: Config.target_value(:basic_auth),
           skip_ssl_validation: Config.target_value(:skip_ssl_validation),
           ssl_ca_file: Config.target_value(:ca_cert) })
   rescue Exception => e

--- a/lib/uaa/stub/uaa.rb
+++ b/lib/uaa/stub/uaa.rb
@@ -15,6 +15,7 @@ require 'uaa'
 require 'uaa/stub/server'
 require 'uaa/stub/scim'
 require 'uaa/cli/version'
+require 'cgi'
 require 'pp'
 
 module CF::UAA
@@ -168,6 +169,7 @@ class StubUAAConn < Stub::Base
     ah = basic_auth_header.split(' ')
     return unless ah[0] =~ /^basic$/i
     ah = Base64::strict_decode64(ah[1]).split(':')
+    ah = ah.map { |item| CGI::unescape(item) }
     client = server.scim.get_by_name(ah[0], :client)
     client if client && client[:client_secret] == ah[1]
   end

--- a/lib/uaa/stub/uaa.rb
+++ b/lib/uaa/stub/uaa.rb
@@ -15,7 +15,6 @@ require 'uaa'
 require 'uaa/stub/server'
 require 'uaa/stub/scim'
 require 'uaa/cli/version'
-require 'cgi'
 require 'pp'
 
 module CF::UAA
@@ -169,7 +168,6 @@ class StubUAAConn < Stub::Base
     ah = basic_auth_header.split(' ')
     return unless ah[0] =~ /^basic$/i
     ah = Base64::strict_decode64(ah[1]).split(':')
-    ah = ah.map { |item| CGI::unescape(item) }
     client = server.scim.get_by_name(ah[0], :client)
     client if client && client[:client_secret] == ah[1]
   end


### PR DESCRIPTION
Depends on released version of https://github.com/cloudfoundry/cf-uaa-lib/pull/80

Why: allow to configure and persist in uaac.yml basic_auth which defined whether basic or oauth2 authorization header should be created.
If oauth2 header is created send also a signal in form of a header variable to UAA - which works if UAA in in compliance mode configured