### PR TITLE
add allowpublic option to client

### DIFF
--- a/lib/uaa/cli/client_reg.rb
+++ b/lib/uaa/cli/client_reg.rb
@@ -28,6 +28,7 @@ class ClientCli < CommonCli
       :refresh_token_validity => 'seconds',
       :redirect_uri => 'list',
       :autoapprove => 'list',
+      :allowpublic => 'list',
       :allowedproviders => 'list',
       :'signup_redirect_url' => 'url'
   }
@@ -46,7 +47,7 @@ class ClientCli < CommonCli
         info[k] = opts[:interact] ?
           info[k] = askd("#{k.to_s.gsub('_', ' ')} (#{p})", default): default
       end
-      if k == :autoapprove && (info[k] == 'true' || info[k] == 'false')
+      if (k == :autoapprove || k == :allowpublic) && (info[k] == 'true' || info[k] == 'false')
         info[k] = !!(info[k] == 'true')
       else
         info[k] = Util.arglist(info[k]) if p == 'list'


### PR DESCRIPTION
This feature needs a UAA with enhancement from https://github.com/cloudfoundry/uaa/pull/1888

Then you can run uaac client ..., e.g.

uaac client update cf --allowpublic true
or
uaac client update <your-client>  --allowpublic true

The option is displayed in uaac client get <id>

Meaning: client can be used for public (or mobile) scenarios where no client_secret (or authorization authentication) is possible but PKCE is used in order to protect the redirect flow