### PR TITLE
Update deprecated File.exists? to File.exist?

### DIFF
--- a/lib/uaa/cli/config.rb
+++ b/lib/uaa/cli/config.rb
@@ -34,7 +34,7 @@ class Config
     if config =~ /^---/ || config == ""
       @config = config == "" ? {} : YAML.load(config)
       @config_file = nil
-    elsif File.exists?(@config_file = config)
+    elsif File.exist?(@config_file = config)
       if (@config = YAML.load_file(@config_file)) && @config.is_a?(Hash)
         @config.each { |k, v| break @config = nil if k.to_s =~ / / }
       end

--- a/lib/uaa/cli/token.rb
+++ b/lib/uaa/cli/token.rb
@@ -180,7 +180,7 @@ class TokenCli < CommonCli
     return unless opts[:cf]
     begin
       cf_target = File.open(CF_TARGET_FILE, 'r') { |f| f.read.strip }
-      tok_json = File.open(CF_TOKEN_FILE, 'r') { |f| f.read } if File.exists?(CF_TOKEN_FILE)
+      tok_json = File.open(CF_TOKEN_FILE, 'r') { |f| f.read } if File.exist?(CF_TOKEN_FILE)
       cf_tokens = Util.json_parse(tok_json, :none) || {}
       cf_tokens[cf_target] = auth_header
       File.open(CF_TOKEN_FILE, 'w') { |f| f.write(cf_tokens.to_json) }


### PR DESCRIPTION
This issue was noticed in our CI when we had bumped our Ruby to the latest for some other component, but later had a build that ran the uaa cli fail.

```
$ uaac target TARGET --skip-ssl-validation
uaac error
NoMethodError: undefined method `exists?' for File:Class
```

Ruby 3.2.0 has removed File.exists?

https://github.com/ruby/ruby/pull/5352