### PR TITLE
Support add, update and delete for client jwt configuration

### DIFF
--- a/cf-uaac.gemspec
+++ b/cf-uaac.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # dependencies
-  s.add_runtime_dependency 'cf-uaa-lib', '~> 4.0.3'
+  s.add_runtime_dependency 'cf-uaa-lib', '~> 4.0.4'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.12'
   s.add_development_dependency 'simplecov', '~> 0.22.0'

--- a/lib/uaa/cli/client_reg.rb
+++ b/lib/uaa/cli/client_reg.rb
@@ -121,6 +121,31 @@ class ClientCli < CommonCli
     }
   end
 
+  define_option :jwks_uri, '--jwks_uri <token_keys endpoint>', 'JWKS token key endpoint'
+  define_option :jwks, '--jwks <json token key set>', 'JWKS token key'
+  desc 'client jwt add [id]', 'Add client jwt trust', :jwks_uri, :jwks do |id|
+    pp scim_request { |cr|
+      ###change_clientjwt(client_id, jwks_uri = nil, jwks = nil, kid = nil, changeMode = nil)
+      cr.change_clientjwt(clientid(id), opts[:jwks_uri], opts[:jwks], nil, 'ADD')
+      'client jwt successfully added'
+    }
+  end
+
+  desc 'client jwt update [id]', 'Update client jwt trust', :jwks_uri, :jwks do |id|
+    pp scim_request { |cr|
+      cr.change_clientjwt(clientid(id), opts[:jwks_uri], opts[:jwks], nil, 'UPDATE')
+      'client jwt successfully set'
+    }
+  end
+
+  define_option :kid, '--kid <key id in json token keys>', 'JWKS token key'
+  desc 'client jwt delete [id]', 'Delete client jwt trust', :kid do |id|
+    pp scim_request { |cr|
+      cr.change_clientjwt(clientid(id), '*', nil, opts[:kid], 'DELETE')
+      'client jwt successfully deleted'
+    }
+  end
+
   private
 
   def update_client(cr, info)

--- a/lib/uaa/stub/uaa.rb
+++ b/lib/uaa/stub/uaa.rb
@@ -414,6 +414,13 @@ class StubUAAConn < Stub::Base
     reply.json(status: 'ok', message: 'secret updated')
   end
 
+  route :put, %r{^/oauth/clients/([^/]+)/clientjwt$}, 'content-type' => %r{application/json} do
+    info = Util.json_parse(request.body, :down)
+    return not_found(match[1]) unless id = server.scim.id(match[1], :client)
+    return bad_request('no client_id given') unless info['client_id']
+    reply.json(status: 'ok', message: 'client jwt updated')
+  end
+
   #----------------------------------------------------------------------------
   # users and groups endpoints
   #

--- a/spec/client_reg_spec.rb
+++ b/spec/client_reg_spec.rb
@@ -78,6 +78,14 @@ describe ClientCli do
       Cli.output.string.should include 'access_denied'
     end
 
+    it "changes it's client jwt" do
+      Cli.run("token client get #{@test_client} -s #{@test_secret}").should be
+      Cli.run('token decode').should be
+      Cli.run("client jwt add #{@test_client} --jwks_uri http://localhost:8080/uaa/token_keys").should be
+      Cli.run("client jwt update #{@test_client} --jwks_uri http://localhost:8080/uaa/token_keys").should be
+      Cli.run("client jwt delete #{@test_client} ").should be
+    end
+
     context 'as updated client' do
 
       before :all do


### PR DESCRIPTION
If a client has client jwt active, you can do private_key_jwt

Depends on https://github.com/cloudfoundry/cf-uaa-lib/pull/93