### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
 


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/cf-uaac/security/code-scanning/4](https://github.com/cloudfoundry/cf-uaac/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so all jobs default to least privilege.  
Best fix here: define at workflow root (right after `on:` block, before `jobs:`) with:

- `contents: read`

This preserves existing behavior (checkout + test execution) while documenting and enforcing token scope regardless of repo/org defaults or future workflow reuse.

File to edit:  
- `.github/workflows/ruby.yml`  
Region: between the trigger section (`on: ...`) and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
