### PR TITLE
Potential fix for code scanning alert no. 3: Dependency download using unencrypted communication channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@
 # subcomponent's license, as noted in the LICENSE file.
 #++
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cf-uaac.gemspec
 gemspec


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/cf-uaac/security/code-scanning/3](https://github.com/cloudfoundry/cf-uaac/security/code-scanning/3)

To fix this, update the Gem source URL from HTTP to HTTPS in `Gemfile` so dependency downloads are encrypted in transit.

Best single fix without changing functionality:
- In `Gemfile`, line 14, replace:
  - `source 'http://rubygems.org'`
  - with `source 'https://rubygems.org'`
- No additional methods, imports, or definitions are needed.
- This preserves dependency resolution behavior while securing transport.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
